### PR TITLE
Provide Camel sink

### DIFF
--- a/camel-sink/pom.xml
+++ b/camel-sink/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>me.escoffier.fluid</groupId>
+    <artifactId>fluid-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>camel-sink</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>me.escoffier.fluid</groupId>
+      <artifactId>fluid-constructs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-core</artifactId>
+      <version>2.20.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/camel-sink/src/main/java/me/escoffier/fluid/camel/sink/CamelSink.java
+++ b/camel-sink/src/main/java/me/escoffier/fluid/camel/sink/CamelSink.java
@@ -1,0 +1,56 @@
+package me.escoffier.fluid.camel.sink;
+
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import io.reactivex.internal.operators.completable.CompletableFromObservable;
+import io.vertx.core.json.JsonObject;
+import me.escoffier.fluid.constructs.Sink;
+import org.apache.camel.CamelContext;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.impl.DefaultCamelContext;
+
+import java.util.concurrent.CompletableFuture;
+
+public class CamelSink<T> implements Sink<T> {
+
+    private final String endpoint;
+
+    private final CamelContext camelContext;
+
+    private final ProducerTemplate producerTemplate;
+
+    public CamelSink(JsonObject config) {
+        endpoint = config.getString("endpoint");
+        camelContext = new DefaultCamelContext();
+        try {
+            camelContext.start();
+            producerTemplate = camelContext.createProducerTemplate();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override public Completable dispatch(T data) {
+        CompletableFuture<Object> result = producerTemplate.asyncSendBody(endpoint, data);
+        return new CompletableFromObservable<>(toObservable(result));
+    }
+
+    public CamelContext camelContext() {
+        return camelContext;
+    }
+
+    // Helpers
+
+    private static <T> Observable<T> toObservable(CompletableFuture<T> future) {
+        return Observable.create(subscriber ->
+                future.whenComplete((result, error) -> {
+                    if (error != null) {
+                        subscriber.onError(error);
+                    } else {
+                        subscriber.onNext(result);
+                        subscriber.onComplete();
+                    }
+                }));
+    }
+
+}

--- a/camel-sink/src/main/java/me/escoffier/fluid/camel/sink/CamelSinkFactory.java
+++ b/camel-sink/src/main/java/me/escoffier/fluid/camel/sink/CamelSinkFactory.java
@@ -1,0 +1,19 @@
+package me.escoffier.fluid.camel.sink;
+
+import io.reactivex.Single;
+import io.vertx.core.json.JsonObject;
+import io.vertx.reactivex.core.Vertx;
+import me.escoffier.fluid.constructs.Sink;
+import me.escoffier.fluid.spi.SinkFactory;
+
+public class CamelSinkFactory implements SinkFactory {
+
+    @Override public String name() {
+        return "camel";
+    }
+
+    @Override public <T> Single<Sink<T>> create(Vertx vertx, JsonObject json) {
+        return Single.just(new CamelSink<>(json));
+    }
+
+}

--- a/camel-sink/src/main/resources/META-INF/services/me.escoffier.fluid.spi.SinkFactory
+++ b/camel-sink/src/main/resources/META-INF/services/me.escoffier.fluid.spi.SinkFactory
@@ -1,0 +1,1 @@
+me.escoffier.fluid.camel.sink.CamelSinkFactory

--- a/camel-sink/src/test/java/me/escoffier/fluid/camel/sink/CamelSinkTest.java
+++ b/camel-sink/src/test/java/me/escoffier/fluid/camel/sink/CamelSinkTest.java
@@ -1,0 +1,37 @@
+package me.escoffier.fluid.camel.sink;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import me.escoffier.fluid.constructs.Source;
+import org.apache.camel.CamelContext;
+import org.apache.camel.builder.RouteBuilder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class CamelSinkTest {
+
+    @Test
+    public void shouldWrapIntegersIntoCamelBodies(TestContext context) throws Exception {
+        Async async = context.async();
+        CamelSink<Integer> sink = new CamelSink<>(
+                new JsonObject().put("endpoint", "direct:test")
+        );
+        CamelContext camelContext = sink.camelContext();
+        camelContext.addRoutes(new RouteBuilder() {
+
+            @Override public void configure() throws Exception {
+                from("direct:test").process(event -> {
+                    if (event.getIn().getBody(Integer.class) == 10) {
+                        async.complete();
+                    }
+                });
+            }
+        });
+
+        Source.from(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).to(sink);
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
     <module>kafka-connector</module>
     <module>vertx-eventbus-connector</module>
     <module>fluid-framework</module>
+    <module>camel-sink</module>
     <module>examples/simple-mediation</module>
   </modules>
 


### PR DESCRIPTION
Hi Clement,

One of the things we need from Fluid is to make it easier for us to generate materialized views of Kafka streams. I'd like to try to reuse Camel for this purpose. For example I'd like to create Camel+ElasticSearch [1] endpoint and use that as my sink.

I have created generic Camel Sink for Fluid, which can be used to consume data events using configurable Camel bridge.

Let me know what do you think of it, and if it is OK to merge it into "work" branch. 

[1] https://github.com/apache/camel/blob/master/components/camel-elasticsearch/src/main/docs/elasticsearch-component.adoc