### PR TITLE
Data expressions proposal

### DIFF
--- a/expression-groovy/pom.xml
+++ b/expression-groovy/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>me.escoffier.fluid</groupId>
+    <artifactId>fluid-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>expression-groovy</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>me.escoffier.fluid</groupId>
+      <artifactId>fluid-constructs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>2.4.11</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/expression-groovy/src/main/java/me/escoffier/fluid/expression/groovy/GroovyDataExpression.java
+++ b/expression-groovy/src/main/java/me/escoffier/fluid/expression/groovy/GroovyDataExpression.java
@@ -1,0 +1,20 @@
+package me.escoffier.fluid.expression.groovy;
+
+import groovy.lang.GroovyShell;
+import me.escoffier.fluid.spi.DataExpression;
+
+public class GroovyDataExpression implements DataExpression {
+
+    private final String expression;
+
+    public GroovyDataExpression(String expression) {
+        this.expression = expression;
+    }
+
+    @Override public Object evaluate(Object data) {
+        GroovyShell groovy = new GroovyShell();
+        groovy.setVariable("data", data);
+        return groovy.evaluate(expression);
+    }
+
+}

--- a/expression-groovy/src/main/java/me/escoffier/fluid/expression/groovy/GroovyDataExpressionFactory.java
+++ b/expression-groovy/src/main/java/me/escoffier/fluid/expression/groovy/GroovyDataExpressionFactory.java
@@ -1,0 +1,24 @@
+package me.escoffier.fluid.expression.groovy;
+
+import me.escoffier.fluid.spi.DataExpression;
+import me.escoffier.fluid.spi.DataExpressionFactory;
+
+public class GroovyDataExpressionFactory implements DataExpressionFactory {
+
+    @Override
+    public boolean supports(Object expression) {
+        if(expression instanceof String) {
+            String stringExpression = (String) expression;
+            return stringExpression.startsWith("groovy:");
+        }
+        return false;
+    }
+
+    @Override
+    public DataExpression create(Object expression) {
+        String stringExpression = (String) expression;
+        String expressionWithoutPrefix = stringExpression.substring(7);
+        return new GroovyDataExpression(expressionWithoutPrefix);
+    }
+
+}

--- a/expression-groovy/src/main/resources/META-INF/services/me.escoffier.fluid.spi.DataExpressionFactory
+++ b/expression-groovy/src/main/resources/META-INF/services/me.escoffier.fluid.spi.DataExpressionFactory
@@ -1,0 +1,1 @@
+me.escoffier.fluid.expression.groovy.GroovyDataExpressionFactory

--- a/expression-groovy/src/test/java/me/escoffier/fluid/expression/groovy/GroovyDataExpressionTest.java
+++ b/expression-groovy/src/test/java/me/escoffier/fluid/expression/groovy/GroovyDataExpressionTest.java
@@ -1,0 +1,28 @@
+package me.escoffier.fluid.expression.groovy;
+
+import org.junit.Test;
+
+import static me.escoffier.fluid.constructs.impl.DataExpressionFactories.requiredEventExpression;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GroovyDataExpressionTest {
+
+    @Test
+    public void shouldEvaluateConstant() {
+        String result = (String) requiredEventExpression("groovy:'foo'").evaluate(null);
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldEvaluateData() {
+        String result = (String) requiredEventExpression("groovy:data").evaluate("foo");
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    public void shouldEvaluateIntegerOperations() {
+        int result = (int) requiredEventExpression("groovy:data * 2").evaluate(2);
+        assertThat(result).isEqualTo(4);
+    }
+
+}

--- a/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/impl/DataExpressionFactories.java
+++ b/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/impl/DataExpressionFactories.java
@@ -1,0 +1,26 @@
+package me.escoffier.fluid.constructs.impl;
+
+import me.escoffier.fluid.spi.DataExpression;
+import me.escoffier.fluid.spi.DataExpressionFactory;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+import static java.util.Optional.empty;
+
+public class DataExpressionFactories {
+
+    public static Optional<DataExpression> eventExpression(String expression) {
+        for (DataExpressionFactory factory : ServiceLoader.load(DataExpressionFactory.class)) {
+            if (factory.supports(expression)) {
+                return Optional.of(factory.create(expression));
+            }
+        }
+        return empty();
+    }
+
+    public static DataExpression requiredEventExpression(String expression) {
+        return eventExpression(expression).orElseThrow(() -> new IllegalStateException("Unknown expression: " + expression));
+    }
+
+}

--- a/fluid-constructs/src/main/java/me/escoffier/fluid/spi/DataExpression.java
+++ b/fluid-constructs/src/main/java/me/escoffier/fluid/spi/DataExpression.java
@@ -1,0 +1,7 @@
+package me.escoffier.fluid.spi;
+
+public interface DataExpression {
+
+    Object evaluate(Object data);
+
+}

--- a/fluid-constructs/src/main/java/me/escoffier/fluid/spi/DataExpressionFactory.java
+++ b/fluid-constructs/src/main/java/me/escoffier/fluid/spi/DataExpressionFactory.java
@@ -1,0 +1,9 @@
+package me.escoffier.fluid.spi;
+
+public interface DataExpressionFactory {
+
+    boolean supports(Object expression);
+
+    DataExpression create(Object expression);
+
+}

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -66,6 +66,12 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>me.escoffier.fluid</groupId>
+      <artifactId>expression-groovy</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kafka-connector/src/test/java/me/escoffier/fluid/kafka/KafkaSinkTest.java
+++ b/kafka-connector/src/test/java/me/escoffier/fluid/kafka/KafkaSinkTest.java
@@ -116,7 +116,8 @@ public class KafkaSinkTest {
             .put("bootstrap.servers", "localhost:9092")
             .put("acks", 1)
             .put("key.serializer", StringSerializer.class.getName())
-            .put("key.deserializer", StringDeserializer.class.getName());
+            .put("key.deserializer", StringDeserializer.class.getName())
+            .put("key", "groovy:null");
     }
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <module>vertx-eventbus-connector</module>
     <module>fluid-framework</module>
     <module>camel-sink</module>
+    <module>expression-groovy</module>
     <module>examples/simple-mediation</module>
   </modules>
 


### PR DESCRIPTION
Hi Clement,

This pull request aims to solve generic issue of JSON configuration being static and therefore not suitable for many use cases. For example, right now KafkaSink specifies key as static String [1], while in real life end users would like to specify key for each data event. So this is not something that you could specify statically on the JSON level with support for expressions evaluation.

Camel and Spring address this kind of issues with expressions API. Spring has its SpEL [2], while Camel provide pluggable expression SPI [3]. I think it would be nice to follow similar approach.

I have created simple SPI for data expression and sample Groovy-based implementation of it. I have also used it in Kafka Sink to evaluate key on every incoming message. So for example you can configure sink as `"key": "groovy:'key'"` if you need a static key or something like `"key": "groovy:$data.key"` if you would like to resolve key dynamically.

Keep also in mind that we can add something like `ConstantDataEventExpression` which could be used as a fallback expression if none of the registered factories matches the given expression. That would allow us to support expressions like `"key": "groovy:'key'"` but supporting `"key": "myConstantKey"` as well (as we do now).

What do you think about such approach, Clement?

Thanks!

[1] https://github.com/cescoffier/fluid/blob/master/kafka-connector/src/main/java/me/escoffier/fluid/kafka/KafkaSink.java#L22
[2] https://docs.spring.io/spring/docs/4.0.x/spring-framework-reference/html/expressions.html
[3] http://camel.apache.org/expression.html