### PR TITLE
Document-based materialized views from streams

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <module>fluid-framework</module>
     <module>camel-sink</module>
     <module>expression-groovy</module>
+    <module>view</module>
     <module>examples/simple-mediation</module>
   </modules>
 

--- a/view/pom.xml
+++ b/view/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>me.escoffier.fluid</groupId>
+    <artifactId>fluid-project</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>view</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>me.escoffier.fluid</groupId>
+      <artifactId>fluid-constructs</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/view/src/main/java/me/escoffier/fluid/view/DocumentView.java
+++ b/view/src/main/java/me/escoffier/fluid/view/DocumentView.java
@@ -1,0 +1,21 @@
+package me.escoffier.fluid.view;
+
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+
+import java.util.Map;
+
+public interface DocumentView {
+
+    Completable save(String collection, String key, Map<String, Object> document);
+
+    Single<Map<String, Object>> findById(String collection, String key);
+
+    Single<Long> count(String collection);
+
+    Observable<DocumentWithKey> findAll(String collection);
+
+    Completable remove(String collection, String key);
+
+}

--- a/view/src/main/java/me/escoffier/fluid/view/DocumentWithKey.java
+++ b/view/src/main/java/me/escoffier/fluid/view/DocumentWithKey.java
@@ -1,0 +1,24 @@
+package me.escoffier.fluid.view;
+
+import java.util.Map;
+
+public class DocumentWithKey {
+
+    private final String key;
+
+    private final Map<String, Object> document;
+
+    public DocumentWithKey(String key, Map<String, Object> document) {
+        this.key = key;
+        this.document = document;
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public Map<String, Object> document() {
+        return document;
+    }
+
+}

--- a/view/src/main/java/me/escoffier/fluid/view/inmemory/InMemoryDocumentView.java
+++ b/view/src/main/java/me/escoffier/fluid/view/inmemory/InMemoryDocumentView.java
@@ -1,0 +1,50 @@
+package me.escoffier.fluid.view.inmemory;
+
+import io.reactivex.Completable;
+import io.reactivex.Observable;
+import io.reactivex.Single;
+import me.escoffier.fluid.view.DocumentView;
+import me.escoffier.fluid.view.DocumentWithKey;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.reactivex.Completable.complete;
+import static io.reactivex.Observable.fromIterable;
+import static io.reactivex.Single.just;
+import static java.util.stream.Collectors.toList;
+
+public class InMemoryDocumentView implements DocumentView {
+
+    private final Map<String, Map<String, Map<String, Object>>> documents = new LinkedHashMap<>();
+
+    synchronized @Override public Completable save(String collection, String key, Map<String, Object> document) {
+        Map<String, Map<String, Object>> collectionData = documents.computeIfAbsent(collection, k -> new LinkedHashMap<>());
+        collectionData.put(key, document);
+        return complete();
+    }
+
+    synchronized @Override public Single<Map<String, Object>> findById(String collection, String key) {
+        Map<String, Map<String, Object>> collectionData = documents.computeIfAbsent(collection, k -> new LinkedHashMap<>());
+        return just(collectionData.get(key));
+    }
+
+    synchronized @Override public Single<Long> count(String collection) {
+        Map<String, Map<String, Object>> collectionData = documents.computeIfAbsent(collection, key -> new LinkedHashMap<>());
+        return just((long) collectionData.size());
+    }
+
+    synchronized @Override public Observable<DocumentWithKey> findAll(String collection) {
+        List<DocumentWithKey> documentsWithIds = documents.computeIfAbsent(collection, key -> new LinkedHashMap<>()).entrySet().stream().
+                map(entry -> new DocumentWithKey(entry.getKey(), entry.getValue())).collect(toList());
+        return fromIterable(documentsWithIds);
+    }
+
+    synchronized @Override public Completable remove(String collection, String key) {
+        Map<String, Map<String, Object>> collectionData = documents.computeIfAbsent(collection, k -> new LinkedHashMap<>());
+        collectionData.remove(key);
+        return complete();
+    }
+
+}

--- a/view/src/test/java/me/escoffier/fluid/view/inmemory/InMemoryDocumentViewTest.java
+++ b/view/src/test/java/me/escoffier/fluid/view/inmemory/InMemoryDocumentViewTest.java
@@ -1,0 +1,90 @@
+package me.escoffier.fluid.view.inmemory;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import me.escoffier.fluid.view.DocumentView;
+import me.escoffier.fluid.view.DocumentWithKey;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(VertxUnitRunner.class)
+public class InMemoryDocumentViewTest {
+
+    DocumentView view = new InMemoryDocumentView();
+
+    String collection = UUID.randomUUID().toString();
+
+    String key = UUID.randomUUID().toString();
+
+    Map<String, Object> document = new LinkedHashMap<>();
+
+    {
+        document.put("foo", "bar");
+    }
+
+    @Test
+    public void shouldSave(TestContext context) {
+        Async async = context.async();
+        view.save(collection, key, document).subscribe(() ->
+                view.findById(collection, key).subscribe(document -> {
+                    assertThat(document).isEqualTo(this.document);
+                    async.complete();
+                })
+        );
+    }
+
+    @Test
+    public void shouldCallSubscriberOnSave(TestContext context) {
+        Async async = context.async();
+        view.save(collection, key, document).subscribe(async::complete);
+    }
+
+    @Test
+    public void shouldCount(TestContext context) {
+        Async async = context.async();
+        view.save(collection, key, document).subscribe(() ->
+                view.findById(collection, key).subscribe(document ->
+                        view.count(collection).subscribe(count -> {
+                            assertThat(count).isEqualTo(1);
+                            async.complete();
+                        })
+                )
+        );
+    }
+
+    @Test
+    public void shouldFindAll() {
+        view.save(collection, key, document).subscribe(() -> {
+            List<DocumentWithKey> documents = new LinkedList<>();
+            view.findById(collection, key).subscribe(document ->
+                    view.findAll(collection).subscribe(documents::add)
+            );
+            assertThat(documents).hasSize(1);
+            assertThat(documents.get(0).key()).isEqualTo(key);
+            assertThat(documents.get(0).document()).isEqualTo(document);
+        });
+    }
+
+    @Test
+    public void shouldRemove(TestContext context) {
+        Async async = context.async();
+        view.save(collection, key, document).subscribe(() ->
+                view.remove(collection, key).subscribe(() ->
+                        view.count(collection).subscribe(count -> {
+                            assertThat(count).isEqualTo(0);
+                            async.complete();
+                        })
+                )
+        );
+    }
+
+}

--- a/view/src/test/java/me/escoffier/fluid/view/inmemory/MaterializedViewTest.java
+++ b/view/src/test/java/me/escoffier/fluid/view/inmemory/MaterializedViewTest.java
@@ -1,0 +1,34 @@
+package me.escoffier.fluid.view.inmemory;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import me.escoffier.fluid.constructs.Source;
+import me.escoffier.fluid.view.DocumentView;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Maps.newHashMap;
+
+@RunWith(VertxUnitRunner.class)
+public class MaterializedViewTest {
+
+    DocumentView materializedView = new InMemoryDocumentView();
+
+    @Test
+    public void shouldGenerateMaterializedView(TestContext context) {
+        Async async = context.async();
+        // Create data set
+        Source.from(1, 2, 3).flow().
+                // Generate materialized view
+                flatMap(it -> done -> materializedView.save("numbers", it + "", newHashMap("number", it)).subscribe(done::onComplete)).
+                subscribe();
+        // Verify that view has been generated
+        materializedView.count("numbers").subscribe(count -> {
+            assertThat(count).isEqualTo(3);
+            async.complete();
+        });
+    }
+
+}


### PR DESCRIPTION
One of the feature that is highly desired in stream processing toolkit is an ability to generate and easily access materialized views. 

For example for our IoT uses cases we need this feature to generate persistent device state from a stream of device updates. Then we need to access this state from REST or AMQP API. The idea here is that Kafka topic represent "the single source of truth" of devices state, while materialized view is a snapshot of the state of the device updates stream - snapshot which can be easily and efficiently accessed via REST/AMQP/MQTT operations. I believe that it would be great to have first-class support for working with materialized views in Fluid.

The common pattern for materialized views we identified is generating view backed by document-oriented persistence engine (like JSON-compatible NoSQL database). So I believe that a great point to start would be to have a RxJava-friendly interface abstracting common operations for document-driven materialized views. I imagine that generating and accessing this abstraction from the end-user code could look as something similar to the following:  

```
// Create data set
Source.from(1, 2, 3).flow().
  // Generate materialized view
  flatMap(it -> done -> materializedView.save("numbers", it + "", newHashMap("number", it)).subscribe(done::onComplete)).
  subscribe();

// Access generated view
materializedView.count("numbers").subscribe(count -> {
  assertThat(count).isEqualTo(3);
});
```

What do you think about such approach?