### PR TITLE
Common headers proposal

### DIFF
--- a/fluid-constructs/pom.xml
+++ b/fluid-constructs/pom.xml
@@ -57,6 +57,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>22.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.6</version>

--- a/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/CommonHeaders.java
+++ b/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/CommonHeaders.java
@@ -1,0 +1,30 @@
+package me.escoffier.fluid.constructs;
+
+import java.util.Optional;
+
+public final class CommonHeaders {
+
+  public static final String KEY = "fluid.key";
+
+  public static final String ORIGINAL = "fluid.original";
+
+  private CommonHeaders() {
+  }
+
+  public static String key(Data data) {
+    return (String) data.get(KEY);
+  }
+
+  public static Optional<String> keyOpt(Data data) {
+    return data.getOpt(KEY);
+  }
+
+  public static <T> T original(Data data) {
+    return (T) data.get(ORIGINAL);
+  }
+
+  public static <T> Optional<T> originalOpt(Data data) {
+    return data.getOpt(ORIGINAL);
+  }
+
+}

--- a/fluid-constructs/src/test/java/me/escoffier/fluid/constructs/CommonHeadersTest.java
+++ b/fluid-constructs/src/test/java/me/escoffier/fluid/constructs/CommonHeadersTest.java
@@ -1,0 +1,39 @@
+package me.escoffier.fluid.constructs;
+
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import static me.escoffier.fluid.constructs.CommonHeaders.KEY;
+import static me.escoffier.fluid.constructs.CommonHeaders.ORIGINAL;
+import static me.escoffier.fluid.constructs.CommonHeaders.key;
+import static me.escoffier.fluid.constructs.CommonHeaders.keyOpt;
+import static me.escoffier.fluid.constructs.CommonHeaders.originalOpt;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommonHeadersTest {
+
+  Data dataWithCommonHeaders = new Data<>("payload", ImmutableMap.of(KEY, "key", ORIGINAL, "original"));
+
+  Data dataWithoutCommonHeaders = new Data<>("payload");
+
+  @Test
+  public void shouldGetRequiredKey() {
+    assertThat(key(dataWithCommonHeaders)).isEqualTo("key");
+  }
+
+  @Test
+  public void shouldHandleEmptyKey() {
+    assertThat(keyOpt(dataWithoutCommonHeaders)).isEmpty();
+  }
+
+  @Test
+  public void shouldGetRequiredOriginalData() {
+    assertThat(CommonHeaders.<String>original(dataWithCommonHeaders)).isEqualTo("original");
+  }
+
+  @Test
+  public void shouldHandleEmptyOriginal() {
+    assertThat(originalOpt(dataWithoutCommonHeaders)).isEmpty();
+  }
+
+}

--- a/kafka-connector/pom.xml
+++ b/kafka-connector/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kafka-connector/src/main/java/me/escoffier/fluid/kafka/KafkaSource.java
+++ b/kafka-connector/src/main/java/me/escoffier/fluid/kafka/KafkaSource.java
@@ -33,10 +33,10 @@ public class KafkaSource<T> extends DataStreamImpl<Void, T> implements Source<T>
   private static <T> Data<T> createDataFromRecord(KafkaConsumerRecord<String, T> record) {
     // TODO need another API to avoid creating so many objects.
     return new Data<>(record.value())
+      .with("record", record)
       .with(ORIGINAL, record)
       .with("timestamp", record.timestamp())
       .with("timestamp-type", record.timestampType())
-      .with("record", record)
       .with("partition", record.partition())
       .with("checksum", record.checksum())
       .with("key", record.key())

--- a/kafka-connector/src/main/java/me/escoffier/fluid/kafka/KafkaSource.java
+++ b/kafka-connector/src/main/java/me/escoffier/fluid/kafka/KafkaSource.java
@@ -11,6 +11,9 @@ import me.escoffier.fluid.constructs.impl.DataStreamImpl;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import static me.escoffier.fluid.constructs.CommonHeaders.KEY;
+import static me.escoffier.fluid.constructs.CommonHeaders.ORIGINAL;
+
 /**
  * @author <a href="http://escoffier.me">Clement Escoffier</a>
  */
@@ -30,12 +33,14 @@ public class KafkaSource<T> extends DataStreamImpl<Void, T> implements Source<T>
   private static <T> Data<T> createDataFromRecord(KafkaConsumerRecord<String, T> record) {
     // TODO need another API to avoid creating so many objects.
     return new Data<>(record.value())
+      .with(ORIGINAL, record)
       .with("timestamp", record.timestamp())
       .with("timestamp-type", record.timestampType())
       .with("record", record)
       .with("partition", record.partition())
       .with("checksum", record.checksum())
       .with("key", record.key())
+      .with(KEY, record.key())
       .with("topic", record.topic());
   }
 
@@ -49,4 +54,5 @@ public class KafkaSource<T> extends DataStreamImpl<Void, T> implements Source<T>
   public String name() {
     return name;
   }
+
 }


### PR DESCRIPTION
Hi,

There is one thing I think we should introduce into Fluid Data/headers concept. Something I would call "common headers".

The motivation behind this is that we should try to provide some generic (aka common) headers aliases that attempt to hide underlying source/sink technology. For example all source implementations that can provide key for the data instance should copy that key into generic "fluid.key" header.

I believe we should do this because each source will generate some transport specific headers (like `partition` or `offset` for Kafka), but at the same time we should provide a way to create more generic functions that can work with *any* transport supporting certain headers type. 

So I could create function like...

```
source.map(data -> CommonHeaders.key(data)).to(...);
``` 

...which will work with any source supporting data keys. That enables us and end users to make it easier to create functions that are not bounded to a specific transport (for example that are not Kafka-aware).

What do you think about such approach?