### PR TITLE
Response callback support proposal

### DIFF
--- a/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/CommonHeaders.java
+++ b/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/CommonHeaders.java
@@ -10,6 +10,8 @@ public final class CommonHeaders {
 
   public static final String KEY = "fluid.key";
 
+  public static final String RESPONSE_CALLBACK = "fluid.response.callback";
+
 
   private CommonHeaders() {
     // Avoid direct instantiation.
@@ -42,6 +44,14 @@ public final class CommonHeaders {
   @SuppressWarnings("unchecked")
   public static Optional<String> keyOpt(Data data) {
     return data.getOpt(KEY);
+  }
+
+  public static ResponseCallback responseCallback(Data data) {
+    return (ResponseCallback) data.get(RESPONSE_CALLBACK);
+  }
+
+  public static Optional<ResponseCallback> responseCallbackOpt(Data data) {
+    return (Optional<ResponseCallback>) data.getOpt(RESPONSE_CALLBACK);
   }
 
 }

--- a/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/ResponseCallback.java
+++ b/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/ResponseCallback.java
@@ -1,7 +1,9 @@
 package me.escoffier.fluid.constructs;
 
+import io.reactivex.Completable;
+
 public interface ResponseCallback {
 
-    void respond(Object response);
+    Completable reply(Object response);
 
 }

--- a/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/ResponseCallback.java
+++ b/fluid-constructs/src/main/java/me/escoffier/fluid/constructs/ResponseCallback.java
@@ -1,0 +1,7 @@
+package me.escoffier.fluid.constructs;
+
+public interface ResponseCallback {
+
+    void respond(Object response);
+
+}

--- a/fluid-constructs/src/test/java/me/escoffier/fluid/constructs/ResponseCallbackTest.java
+++ b/fluid-constructs/src/test/java/me/escoffier/fluid/constructs/ResponseCallbackTest.java
@@ -1,0 +1,37 @@
+package me.escoffier.fluid.constructs;
+
+import org.junit.Test;
+
+import java.util.Date;
+
+import static me.escoffier.fluid.constructs.CommonHeaders.RESPONSE_CALLBACK;
+import static me.escoffier.fluid.constructs.CommonHeaders.responseCallback;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ResponseCallbackTest {
+
+  @Test
+  public void shouldExecuteResponseCallback() {
+    // Given
+    DateResponseCallback responseCallback = new DateResponseCallback();
+    Data<String> data = new Data<>("payload").with(RESPONSE_CALLBACK, responseCallback);
+    long timeResponse = 666;
+
+    // When
+    responseCallback(data).respond(timeResponse);
+
+    // Then
+    assertThat(responseCallback.date.getTime()).isEqualTo(666);
+  }
+
+  static class DateResponseCallback implements ResponseCallback {
+
+    Date date = new Date();
+
+    @Override public void respond(Object response) {
+      date.setTime((long)response);
+    }
+
+  }
+
+}

--- a/fluid-constructs/src/test/java/me/escoffier/fluid/constructs/ResponseCallbackTest.java
+++ b/fluid-constructs/src/test/java/me/escoffier/fluid/constructs/ResponseCallbackTest.java
@@ -1,9 +1,13 @@
 package me.escoffier.fluid.constructs;
 
+import io.reactivex.Completable;
+import io.reactivex.internal.operators.completable.CompletableErrorSupplier;
 import org.junit.Test;
 
 import java.util.Date;
 
+import static io.reactivex.Completable.complete;
+import static io.reactivex.Completable.error;
 import static me.escoffier.fluid.constructs.CommonHeaders.RESPONSE_CALLBACK;
 import static me.escoffier.fluid.constructs.CommonHeaders.responseCallback;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,18 +22,40 @@ public class ResponseCallbackTest {
     long timeResponse = 666;
 
     // When
-    responseCallback(data).respond(timeResponse);
+    responseCallback(data).reply(timeResponse).subscribe();
 
     // Then
     assertThat(responseCallback.date.getTime()).isEqualTo(666);
+  }
+
+  @Test
+  public void shouldPropagateReplyErrorDownstream() {
+    // Given
+    ErroringResponseCallback responseCallback = new ErroringResponseCallback();
+    Data<String> data = new Data<>("payload").with(RESPONSE_CALLBACK, responseCallback);
+
+    // When
+    Completable replyResult = responseCallback(data).reply(new Object());
+
+    // Then
+    assertThat(replyResult).isInstanceOf(CompletableErrorSupplier.class);
   }
 
   static class DateResponseCallback implements ResponseCallback {
 
     Date date = new Date();
 
-    @Override public void respond(Object response) {
+    @Override public Completable reply(Object response) {
       date.setTime((long)response);
+      return complete();
+    }
+
+  }
+
+  static class ErroringResponseCallback implements ResponseCallback {
+
+    @Override public Completable reply(Object response) {
+      return error(RuntimeException::new);
     }
 
   }


### PR DESCRIPTION
Hi Clement,

I'd like propose an approach to handle request/reply use cases in Fluid.

IMHO at the very low level we should provide an abstraction that can be implemented by sources if they provide a way to handle request-reply communication. Implementation of this abstraction could be added as a standard header to the data event. So end user can read it from a data and send a response back to the source.

So from end user point of view sending response back to source, could look as follows:

```
source.consume(data-> responseCallback(data).respond("Hello world!"));
```

For example this [1] is how response callback could look for HTTP source (we don't have one yet, so this is a project implementing a prototype I'm experimenting with). And this [1] is how such response could be sent. Here is another example implementation [3] I did for a Slack source prototype. And here [4] is an example of sending response back to Slack bot using this abstraction.

We can also add a DSL element which could be used to simplify using this abstraction even more. Something like:

```
httpSource.reply(data-> "Hello world!");
```

What do you think about such approach?

[1] https://github.com/hekonsek/rxjava-connector-http/blob/master/src/main/java/com/github/hekonsek/rxjava/connector/http/VertxHttpResponseCallback.java
[2] https://github.com/hekonsek/rxjava-connector-http/blob/master/src/test/java/com/github/hekonsek/rxjava/connector/http/HttpSourceTest.java#L82
[3] https://github.com/hekonsek/rxjava-connector-slack/blob/master/src/main/java/com/github/hekonsek/rxjava/connector/slack/SlackResponseCallback.java
[4] https://github.com/hekonsek/rxjava-connector-slack#usage